### PR TITLE
fix: sending streets in the right order

### DIFF
--- a/backend/calculate.py
+++ b/backend/calculate.py
@@ -2,6 +2,7 @@ import googlemaps
 import re
 import requests
 import os
+from collections import OrderedDict
 from datetime import datetime
 from elevationAPI import elevation
 
@@ -91,9 +92,11 @@ def calculate_route(origin, destination):
     now = datetime.now()
 
     directions_result = gmaps.directions(origin, destination, mode="walking", departure_time=now)
-    directions_result = set(extract_street_names(directions_result))
+    streets = extract_street_names(directions_result)
+    # Remove duplicates from the streets list, keeping the order
+    directions_result = list(dict.fromkeys(streets).keys())
 
-    weather_streets = {}
+    weather_streets = OrderedDict()
     for street in directions_result:
         lat, lng = get_geolocation(f'{street}, recife').values()
         weather = get_weather(lat, lng)


### PR DESCRIPTION
## BugFix

- Anteriormente, as ruas da rota estavam sendo enviadas sem ordem específica, pois estávamos utilizando `set` para remover as ruas duplicadas, e essa estrutura de dados em Python não tem ordem, assim como o `Dict` que estava sendo usado para enviar as ruas para o frontend.
- Foi modificado o `setlist ` seguindo a referência descrita abaixo, e o `Dict` foi substituído por `OrderedDict`

#### Antes:

![image](https://github.com/user-attachments/assets/b853c4f3-4bfd-43e1-b984-ab6af9440466)

#### Depois:

![image](https://github.com/user-attachments/assets/c6c1beb5-f4d9-450d-82dd-c6921bfd255e)


### Referências:
- https://stackoverflow.com/questions/9792664/converting-a-list-to-a-set-changes-element-order#comment109044608_9792664
- https://www.geeksforgeeks.org/ordereddict-in-python/